### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After that, you can subscribe to `revealViewSignal` to get `:next` events when t
 Refer to the header file [`CADRACSwippableCell.h`](Source/CADRACSwippableCell.h) for more documentation.
 
 ###Install
-We strongly encourage you to use Cocoapods. It's simple, just add the dependency to your `Podfile`:
+We strongly encourage you to use CocoaPods. It's simple, just add the dependency to your `Podfile`:
 
 ```ruby
 platform :ios, '7.0'
@@ -66,7 +66,7 @@ And you are done!
 
 ### Demo
 
-To check the demo, first install the dependencies with Cocoapods. After that, build and run the `Example` project in Xcode.
+To check the demo, first install the dependencies with CocoaPods. After that, build and run the `Example` project in Xcode.
 
 
 ## MIT License


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
